### PR TITLE
fixed typo: C2 -> S2

### DIFF
--- a/boards/esp32-s2-devkitm-1/board.json
+++ b/boards/esp32-s2-devkitm-1/board.json
@@ -1,5 +1,5 @@
 {
-  "name": "ESP32-C2-DevKitM-1",
+  "name": "ESP32-S2-DevKitM-1",
   "version": 1,
   "description": "An entry-level ESP32-S2 development board",
   "author": "Uri Shaked",


### PR DESCRIPTION
probably not important, but the name was "ESP32-*C*2-DevKitM-1", and I'm sure it must be "ESP32-*S*2-DevKitM-1"