### PR TITLE
feat: updated to point to latest bug release version of linked chip

### DIFF
--- a/boards/ds18b20/board.json
+++ b/boards/ds18b20/board.json
@@ -6,7 +6,7 @@
   "width": 8.564,
   "height": 13.388,
 
-  "chips": [{ "id": "chip", "type": "github:bonnyr/wokwi-ds1820-custom-chip@0.4.1" }],
+  "chips": [{ "id": "chip", "type": "github:bonnyr/wokwi-ds1820-custom-chip@0.4.4" }],
 
   "pins": {
     "GND": { "x": 1.46, "y": 13, "target": "chip:GND" },


### PR DESCRIPTION
Updated board.json to point to latest bug fix release - https://github.com/bonnyr/wokwi-ds1820-custom-chip/releases/tag/v0.4.4
(corrected negative temperature reporting on bs18b20) 